### PR TITLE
Makefile: remove stray, unintended-looking slash in use of $CFITSIODIR

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@ LIBS=$(GRTRANSDIR)/libcfitsio_phi.a
 LINKFLAGS=$(OMP) $(PHIFLAGS)
 else
 LINKFLAGS=$(OMP)
-LIBS=-L/$(CFITSIODIR) -lcfitsio
+LIBS=-L$(CFITSIODIR) -lcfitsio
 endif
 
 .DEFAULT:


### PR DESCRIPTION
Very quick (and unimportant...) tidying.