### PR TITLE
Makefile: add a "-g" flag to f90 when compiling in DEBUG mode

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ OMPLIB = -lgomp
 FCNAME=gnu95
 PHIFLAGS=
 ifeq ($(DEBUG),1)
-OTHERFLAGS = -ffixed-line-length-132 -pg -W -Wall -fPIC
+OTHERFLAGS = -ffixed-line-length-132 -g -pg -W -Wall -fPIC
 #OMP=
 #OMPLIB=
 else


### PR DESCRIPTION
Perhaps on other systems this is implicit in "-pg", but for me I don't get debug symbols unless there's a standalone "-g".